### PR TITLE
Multi Arch builds on native runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,36 +65,36 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           annotations: ${{ steps.meta.outputs.annotations }}
 
-  trigger:
-    needs: build
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        repos: ["aiida-gpcr",
-                "aiida-lysozyme",
-                "basic-analysis",
-                "basic-statistics",
-                "beginners",
-                "clustering",
-                "codeentropy",
-                "docking",
-                "enhanced-sampling",
-                "equilibration",
-                "introamber",
-                "nemd",
-                "openff",
-                "pca",
-                "pdb2pqr",
-                "python",
-                "qmmm",
-                "structure-validation",
-                "ubiquitin-analysis"]
-    name: jupyterhub-${{ matrix.jupyter-base }}
-    steps:  
-      - name: Repository Dispatch Build Trigger
-        uses: peter-evans/repository-dispatch@v3.0.0
-        with:
-          token: ${{ secrets.BUILD_TOKEN }}
-          repository: jimboid/biosim-${{ matrix.repos }}-workshop
-          event-type: build    
-          client-payload: '{"tag": "${{ needs.build.outputs.tag }}"}'
+#  trigger:
+#    needs: build
+#    runs-on: ubuntu-24.04
+#    strategy:
+#      matrix:
+#        repos: ["aiida-gpcr",
+#                "aiida-lysozyme",
+#                "basic-analysis",
+#                "basic-statistics",
+#                "beginners",
+#                "clustering",
+#                "codeentropy",
+#                "docking",
+#                "enhanced-sampling",
+#                "equilibration",
+#                "introamber",
+#                "nemd",
+#                "openff",
+#                "pca",
+#                "pdb2pqr",
+#                "python",
+#                "qmmm",
+#                "structure-validation",
+#                "ubiquitin-analysis"]
+#    name: jupyterhub-${{ matrix.jupyter-base }}
+#    steps:  
+#      - name: Repository Dispatch Build Trigger
+#        uses: peter-evans/repository-dispatch@v3.0.0
+#        with:
+#          token: ${{ secrets.BUILD_TOKEN }}
+#          repository: jimboid/biosim-${{ matrix.repos }}-workshop
+#          event-type: build    
+#          client-payload: '{"tag": "${{ needs.build.outputs.tag }}"}'


### PR DESCRIPTION
Building on native hardware will speed things in the build pipeline considerably. Should also be easier to debug arm when it goes wrong compared to QEMU virt.